### PR TITLE
Implement stack frames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,7 +996,7 @@ dependencies = [
 
 [[package]]
 name = "mustermann"
-version = "9.0.0"
+version = "11.0.0"
 dependencies = [
  "anyhow",
  "clap",


### PR DESCRIPTION
This PR implements stack frame functionality.

A new stack frame gets allocated whenever we execute a `call`. On the other hand, a stack frame gets dropped when we encounter a `ret`.